### PR TITLE
Unaligned access

### DIFF
--- a/rex/src/sched_cls/sched_cls_impl.rs
+++ b/rex/src/sched_cls/sched_cls_impl.rs
@@ -203,7 +203,10 @@ impl sched_cls {
 
     // NOTE: copied from xdp impl, may change in the future
     #[inline(always)]
-    pub fn eth_header<'b>(&self, skb: &'b mut __sk_buff) -> &'b mut ethhdr {
+    pub fn eth_header<'b>(
+        &self,
+        skb: &'b mut __sk_buff,
+    ) -> AlignedMut<'b, ethhdr> {
         unsafe {
             convert_slice_to_struct_mut::<ethhdr>(
                 &mut skb.data_slice[0..mem::size_of::<ethhdr>()],
@@ -212,7 +215,10 @@ impl sched_cls {
     }
 
     #[inline(always)]
-    pub fn udp_header<'b>(&self, skb: &'b mut __sk_buff) -> &'b mut udphdr {
+    pub fn udp_header<'b>(
+        &self,
+        skb: &'b mut __sk_buff,
+    ) -> AlignedMut<'b, udphdr> {
         // NOTE: this assumes packet has ethhdr and iphdr
         let begin = mem::size_of::<ethhdr>() + mem::size_of::<iphdr>();
         let end = mem::size_of::<udphdr>() + begin;
@@ -225,7 +231,10 @@ impl sched_cls {
     }
 
     #[inline(always)]
-    pub fn tcp_header<'b>(&self, skb: &'b mut __sk_buff) -> &'b mut tcphdr {
+    pub fn tcp_header<'b>(
+        &self,
+        skb: &'b mut __sk_buff,
+    ) -> AlignedMut<'b, tcphdr> {
         // NOTE: this assumes packet has ethhdr and iphdr
         let begin = mem::size_of::<ethhdr>() + mem::size_of::<iphdr>();
         let end = mem::size_of::<tcphdr>() + begin;
@@ -238,7 +247,10 @@ impl sched_cls {
     }
 
     #[inline(always)]
-    pub fn ip_header<'b>(&self, skb: &'b mut __sk_buff) -> &'b mut iphdr {
+    pub fn ip_header<'b>(
+        &self,
+        skb: &'b mut __sk_buff,
+    ) -> AlignedMut<'b, iphdr> {
         // NOTE: this assumes packet has ethhdr
         let begin = mem::size_of::<ethhdr>();
         let end = mem::size_of::<iphdr>() + begin;

--- a/rex/src/utils.rs
+++ b/rex/src/utils.rs
@@ -1,5 +1,6 @@
 use core::ffi::{c_int, c_uchar};
 use core::mem;
+use core::ops::{Deref, DerefMut};
 
 #[repr(transparent)]
 #[derive(Copy, Clone)]
@@ -37,30 +38,6 @@ macro_rules! to_result {
 }
 pub(crate) use to_result;
 
-// User can get the customized struct like memcached from the data_slice
-// TODO: add a bound checking for this function, add size check
-#[inline(always)]
-pub unsafe fn convert_slice_to_struct<T: NoRef>(slice: &[c_uchar]) -> &T {
-    assert!(
-        slice.len() >= mem::size_of::<T>(),
-        "size mismatch in convert_slice_to_struct"
-    );
-
-    unsafe { &*(slice.as_ptr() as *const T) }
-}
-
-#[inline(always)]
-pub unsafe fn convert_slice_to_struct_mut<T: NoRef>(
-    slice: &mut [c_uchar],
-) -> &mut T {
-    assert!(
-        slice.len() >= mem::size_of::<T>(),
-        "size mismatch in convert_slice_to_struct_mut"
-    );
-
-    unsafe { &mut *(slice.as_mut_ptr() as *mut T) }
-}
-
 /// A marker trait that prevents derivation on types that contain references or
 /// raw pointers. This avoids accidental dereference of invalid pointers in
 /// foreign objects obtained from the kernel (e.g. via `bpf_map_lookup_elem` or
@@ -75,3 +52,192 @@ impl<T: ?Sized> !NoRef for &T {}
 impl<T: ?Sized> !NoRef for &mut T {}
 impl<T: ?Sized> !NoRef for *const T {}
 impl<T: ?Sized> !NoRef for *mut T {}
+
+/// An enum used internally by `Aligned` and `AlignedMut`, the encapsulated
+/// value is either a reference to the data if the aligned requirement is
+/// satisfied, or a copied value of the data if it is not aligned and a
+/// reference cannot be taken directly.
+enum AlignedInner<RefT, ValT> {
+    Ref(RefT),
+    Val(ValT),
+}
+
+/// An abstraction over a `&T` for both aligned and unaligned accesses. This
+/// struct can be constructed with [`convert_slice_to_struct`] from an
+/// underlying data slice. The underlying data is either a direct `&'a T` by
+/// reborrowing the slice or a copied value of `T` from the slice, depending on
+/// whether the slice pointer is properly aligned for `T`.
+///
+/// The abstraction provided by this struct is a shared reference, for an
+/// abstraction over mutable references, use [`AlignedMut`].
+pub struct Aligned<'a, T> {
+    inner: AlignedInner<&'a T, T>,
+}
+
+impl<'a, T> Aligned<'a, T> {
+    /// Constructs an `Aligned<'a, T>` from an aligned reference.
+    #[inline(always)]
+    pub(crate) const fn from_ref(aligned_ref: &'a T) -> Self {
+        Self {
+            inner: AlignedInner::Ref(aligned_ref),
+        }
+    }
+
+    /// Constructs an `Aligned<'a, T>` from a copied value of `T` to handle
+    /// unaligned cases.
+    #[inline(always)]
+    pub(crate) const fn from_val(copied_val: T) -> Self {
+        Self {
+            inner: AlignedInner::Val(copied_val),
+        }
+    }
+}
+
+/// Allows users of `Aligned<'_, T>` to transparently access the value behind
+/// the reference abstraction.
+impl<T> Deref for Aligned<'_, T> {
+    type Target = T;
+
+    /// If the underlying data is a `&T`, it is directly returned;
+    /// otherwise a shared reference to the copied value of `T` is taken and
+    /// returned.
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        match &self.inner {
+            AlignedInner::Ref(aligned_ref) => aligned_ref,
+            AlignedInner::Val(ref unaligned_val) => unaligned_val,
+        }
+    }
+}
+
+/// An abstraction over a `&mut T` for both aligned and unaligned accesses. This
+/// struct can be constructed with [`convert_slice_to_struct_mut`] from an
+/// underlying data slice. The underlying data is either a direct `&'a mut T` by
+/// reborrowing the slice or a copied value of `T` from the slice, depending on
+/// whether the slice pointer is properly aligned for `T`.
+///
+/// The abstraction provided by this struct is a mutable reference, for an
+/// abstraction over shared references, use [`Aligned`].
+pub struct AlignedMut<'a, T> {
+    inner: AlignedInner<&'a mut T, T>,
+}
+
+impl<'a, T> AlignedMut<'a, T> {
+    /// Constructs an `AlignedMut<'a, T>` from an aligned reference.
+    #[inline(always)]
+    pub(crate) const fn from_ref(aligned_ref: &'a mut T) -> Self {
+        Self {
+            inner: AlignedInner::Ref(aligned_ref),
+        }
+    }
+
+    /// Constructs an `AlignedMut<'a, T>` from a copied value of `T` to handle
+    /// unaligned cases.
+    #[inline(always)]
+    pub(crate) const fn from_val(copied_val: T) -> Self {
+        Self {
+            inner: AlignedInner::Val(copied_val),
+        }
+    }
+}
+
+/// Allows users of `AlignedMut<'_, T>` to transparently access the value behind
+/// the reference abstraction.
+impl<T> Deref for AlignedMut<'_, T> {
+    type Target = T;
+
+    /// If the underlying data is a `&mut T`, the coerced `&T` is returned;
+    /// otherwise a shared reference to the copied value of `T` is taken and
+    /// returned.
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        match &self.inner {
+            AlignedInner::Ref(aligned_ref) => aligned_ref,
+            AlignedInner::Val(ref unaligned_val) => unaligned_val,
+        }
+    }
+}
+
+/// Allows users of `AlignedMut<'_, T>` to transparently access and mutate the
+/// value behind the reference abstraction.
+impl<T> DerefMut for AlignedMut<'_, T> {
+    /// If the underlying data is a `&mut T`, it is directly returned;
+    /// otherwise a mutable reference to the copied value of `T` is taken and
+    /// returned.
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match &mut self.inner {
+            AlignedInner::Ref(aligned_ref) => aligned_ref,
+            AlignedInner::Val(ref mut unaligned_val) => unaligned_val,
+        }
+    }
+}
+
+/// Converts the bytes in `slice` into a `&T` abstracted by [`Aligned<'_, T>`].
+/// This is only performed on the first `core::mem::size_of::<T>()` bytes.
+/// If the slice is not long enough, this function panics.
+///
+/// If `slice.as_ptr()` is properly aligned for `T`, the pointer is reborrowed
+/// into a `&T` and stored in the returned `Aligned<'_, T>`.
+/// If the pointer does not satisfy the alignment requirement of `T`, this
+/// function copies the value via `core::ptr::read_unaligned` and stores it in
+/// the returned `Aligned<'_, T>`.
+///
+/// The [operation][read_unaligned_doc] performed in the unaligned case implies
+/// that `T` has to be [`Copy`].
+///
+/// [read_unaligned_doc]: https://doc.rust-lang.org/core/ptr/fn.read_unaligned.html
+#[inline]
+pub fn convert_slice_to_struct<T>(slice: &[c_uchar]) -> Aligned<'_, T>
+where
+    T: Copy + NoRef,
+{
+    assert!(
+        slice.len() >= mem::size_of::<T>(),
+        "size mismatch in convert_slice_to_struct"
+    );
+
+    let ptr = slice.as_ptr() as *const T;
+
+    if ptr.is_aligned() {
+        unsafe { Aligned::from_ref(&*ptr) }
+    } else {
+        unsafe { Aligned::from_val(ptr.read_unaligned()) }
+    }
+}
+
+/// Converts the bytes in `slice` into a `&mut T` abstracted by
+/// [`AlignedMut<'_, T>`].
+/// This is only performed on the first `core::mem::size_of::<T>()` bytes.
+/// If the slice is not long enough, this function panics.
+///
+/// If `slice.as_mut_ptr()` is properly aligned for `T`, the pointer is
+/// reborrowed into a `&mut T` and stored in the returned `AlignedMut<'_, T>`.
+/// If the pointer does not satisfy the alignment requirement of `T`, this
+/// function copies the value via `core::ptr::read_unaligned` and stores it in
+/// the returned `AlignedMut<'_, T>`.
+///
+/// The [operation][read_unaligned_doc] performed in the unaligned case implies
+/// that `T` has to be [`Copy`].
+///
+/// [read_unaligned_doc]: https://doc.rust-lang.org/core/ptr/fn.read_unaligned.html
+#[inline]
+pub fn convert_slice_to_struct_mut<T>(
+    slice: &mut [c_uchar],
+) -> AlignedMut<'_, T>
+where
+    T: Copy + NoRef,
+{
+    assert!(
+        slice.len() >= mem::size_of::<T>(),
+        "size mismatch in convert_slice_to_struct_mut"
+    );
+
+    let ptr = slice.as_mut_ptr() as *mut T;
+
+    if ptr.is_aligned() {
+        unsafe { AlignedMut::from_ref(&mut *ptr) }
+    } else {
+        unsafe { AlignedMut::from_val(ptr.read_unaligned()) }
+    }
+}

--- a/rex/src/xdp/xdp_impl.rs
+++ b/rex/src/xdp/xdp_impl.rs
@@ -134,7 +134,10 @@ impl xdp {
     }
 
     #[inline(always)]
-    pub fn tcp_header<'b>(&'b self, ctx: &'b mut xdp_md) -> &'b mut tcphdr {
+    pub fn tcp_header<'b>(
+        &self,
+        ctx: &'b mut xdp_md,
+    ) -> AlignedMut<'b, tcphdr> {
         // NOTE: this assumes packet has ethhdr and iphdr
         let begin = mem::size_of::<ethhdr>() + mem::size_of::<iphdr>();
         let end = mem::size_of::<tcphdr>() + begin;
@@ -147,7 +150,10 @@ impl xdp {
     }
 
     #[inline(always)]
-    pub fn udp_header<'b>(&self, ctx: &'b mut xdp_md) -> &'b mut udphdr {
+    pub fn udp_header<'b>(
+        &self,
+        ctx: &'b mut xdp_md,
+    ) -> AlignedMut<'b, udphdr> {
         // NOTE: this assumes packet has ethhdr and iphdr
         let begin = mem::size_of::<ethhdr>() + mem::size_of::<iphdr>();
         let end = mem::size_of::<udphdr>() + begin;
@@ -159,9 +165,8 @@ impl xdp {
         }
     }
 
-    // WARN: currently we are accessing unaligned struct for iphdr
     #[inline(always)]
-    pub fn ip_header<'b>(&self, ctx: &'b mut xdp_md) -> &'b mut iphdr {
+    pub fn ip_header<'b>(&self, ctx: &'b mut xdp_md) -> AlignedMut<'b, iphdr> {
         // NOTE: this assumes packet has ethhdr
         let begin = mem::size_of::<ethhdr>();
         let end = mem::size_of::<iphdr>() + begin;
@@ -174,7 +179,10 @@ impl xdp {
     }
 
     #[inline(always)]
-    pub fn eth_header<'b>(&self, ctx: &'b mut xdp_md) -> &'b mut ethhdr {
+    pub fn eth_header<'b>(
+        &self,
+        ctx: &'b mut xdp_md,
+    ) -> AlignedMut<'b, ethhdr> {
         unsafe {
             convert_slice_to_struct_mut::<ethhdr>(
                 &mut ctx.data_slice[0..mem::size_of::<ethhdr>()],

--- a/samples/xdp_test/src/main.rs
+++ b/samples/xdp_test/src/main.rs
@@ -12,7 +12,7 @@ use rex::{rex_tc, rex_xdp};
 
 #[rex_xdp]
 fn xdp_rx_filter(obj: &xdp, ctx: &mut xdp_md) -> Result {
-    let ip_header: &mut iphdr = obj.ip_header(ctx);
+    let mut ip_header = obj.ip_header(ctx);
 
     bpf_printk!(
         obj,
@@ -40,7 +40,7 @@ fn xdp_rx_filter(obj: &xdp, ctx: &mut xdp_md) -> Result {
 
 #[rex_tc]
 fn xdp_tx_filter(obj: &sched_cls, skb: &mut __sk_buff) -> Result {
-    let ip_header = obj.ip_header(skb);
+    let mut ip_header = obj.ip_header(skb);
 
     bpf_printk!(
         obj,


### PR DESCRIPTION
Copied from commit messages:

Introduce the `Aligned<'_, T>` and `AlignedMut<'_, T>` wrapper types to safely abstract potentially unaligned references of a target type `T` obtained from packet payloads (in the form of `&mut [c_uchar]`) via `convert_slice_to_struct{,_mut}()`.

If the reference converted from the slice pointer is aligned for `T`, then these types directly store that reference. Otherwise, a copied value of `T` is obtained via `core::ptr::read_unaligned::<T>()` and stored instead.

By implementing `Deref` and `DerefMut`, these types expose an abstraction such that user code can work with them as if they are `&T` and `&mut T`.

`AlignedMut<'_, T>` also implements `Drop` to perform automatic writeback to the original packet (`&mut [c_uchar]`). The `drop` implementation will only write back to the slice if a value has been copied to avoid unaligned accesses. This is the last piece to allow user code to treat `AlignedMut<'_, T>` as `&mut T`, all the house keeping on the unaligned case (i.e., copy and writeback) are transparent to user code.

This also allows us to mark `convert_slice_to_struct{,_mut}()` as safe -- the `NoRef` bounds and these newly introduced wrapper types should be able to guarantee soundness.