### PR TITLE
Bootstrap config

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -26,8 +26,6 @@ jobs:
         with:
           path: build
           key: ${{ runner.os }}-${{ runner.name }}-meson-${{ hashFiles('rex-native.ini', 'meson.build') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.name }}-meson
 
       - name: Setup Rex build directory
         run: meson setup --native-file rex-native.ini --reconfigure ./build

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ rust_bootstrap = custom_target(
     '--set', 'install.prefix=@OUTDIR@/rust-dist'
   ],
   console: true,
+  env: ['RUSTFLAGS=-Z threads=8 -C target-cpu=native -C codegen-units=1 -C link-arg=-fuse-ld=mold -C link-arg=-Wl,-O1 -C link-arg=-Wl,--as-needed -C link-arg=-flto=thin'],
   build_by_default: false
 )
 


### PR DESCRIPTION
Changes on bootstrap itself
- use 8 threads in frontend (`-Z threads=8`)
- use 1 codegen units (`-C codegen-units=1`)
- generate code for native microarchitecture (`-C target-cpu=native`)
- use mold as linker for rust artifacts (`-C link-arg=-fuse-ld=mold`)
- enable thin LTO on both `llvm` backend and `rustc_driver`
- additional linker flags (`-C link-arg=-Wl,-O1 -C link-arg=-Wl,--as-needed`)

Changes on artifacts
- the `polly` optimizer is enabled in the backend and can be used by `rustc`.
- default number of codegen units is set to 1 for the bootstrapped `rustc`.