### PR TITLE
flake: add openssl to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,7 @@
         getopt
         gnumake
         ncurses
+        openssl
         openssl.dev
         pahole
         pkg-config


### PR DESCRIPTION
Fix issue #9 by adding `openssl` to `flake.nix`