### PR TITLE
Revert bootstrap config

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -55,7 +55,6 @@ rust_bootstrap = custom_target(
     '--set', 'install.prefix=@OUTDIR@/rust-dist'
   ],
   console: true,
-  env: ['RUSTFLAGS=-Z threads=8 -C target-cpu=native -C codegen-units=1 -C link-arg=-fuse-ld=mold -C link-arg=-Wl,-O1 -C link-arg=-Wl,--as-needed -C link-arg=-flto=thin'],
   build_by_default: false
 )
 


### PR DESCRIPTION
We are seeing some random build failures on Zen4: https://github.com/rex-rs/rex/actions/runs/14015580741/job/39240866094

Let's backoff for now.