### PR TITLE
Tracepoint improve

### DIFF
--- a/rex-macros/src/tracepoint.rs
+++ b/rex-macros/src/tracepoint.rs
@@ -1,12 +1,11 @@
 use proc_macro2::TokenStream;
-use proc_macro_error::OptionExt;
+use proc_macro_error::{abort_call_site, OptionExt};
 use quote::{format_ident, quote};
-use syn::{parse2, ItemFn, Result};
+use syn::{parse2, FnArg, ItemFn, Result, Type};
 
 use crate::args::parse_string_args;
 
 pub(crate) struct TracePoint {
-    tp_type: Option<String>,
     name: Option<String>,
     item: ItemFn,
 }
@@ -23,17 +22,46 @@ impl TracePoint {
         let args = parse_string_args(attrs)?;
 
         let name = pop_string_args!(args, "name");
-        let tp_type = pop_string_args!(args, "tp_type");
 
-        Ok(TracePoint {
-            tp_type,
-            name,
-            item,
-        })
+        Ok(TracePoint { name, item })
     }
 
     pub(crate) fn expand(&self) -> Result<TokenStream> {
         let fn_name = self.item.sig.ident.clone();
+
+        // get context type and corresponding tp_type name
+        let FnArg::Typed(context_arg) =
+            self.item.sig.inputs.last().unwrap().clone()
+        else {
+            abort_call_site!("Program needs non-self arguments");
+        };
+        let Type::Reference(context_type_ref) = *context_arg.ty else {
+            abort_call_site!("Context type needs to be behind a reference");
+        };
+        if context_type_ref
+            .lifetime
+            .expect_or_abort("Context reference needs to be static")
+            .ident
+            != "static"
+        {
+            abort_call_site!("Context reference needs to be static");
+        }
+        let context_type = match *context_type_ref.elem {
+            Type::Verbatim(t) => parse2(t).unwrap(),
+            Type::Path(p) => p.path.segments.last().unwrap().clone().ident,
+            _ => {
+                abort_call_site!("Tracepoint context needs to be a literal type or a path to such")
+            }
+        };
+        let context_type_name = format!("{}", context_type);
+        let ctx_variant = format_ident!(
+            "{}",
+            context_type_name
+                .strip_suffix("Args")
+                .expect_or_abort("Not valid context type")
+        );
+
+        // other tracepoint pieces
         let item = &self.item;
         let function_name = format!("{}", fn_name);
         let prog_ident =
@@ -46,27 +74,31 @@ impl TracePoint {
             )
         );
 
-        let tp_type_str = self
-            .tp_type
-            .as_ref()
-            .expect_or_abort("Please provide valid tracepoint attached point")
-            .as_str();
-
-        let tp_type = match tp_type_str {
-            "Void" => quote!(tp_type::Void),
-            "SyscallsEnterOpen" => quote!(tp_type::SyscallsExitOpen),
+        let tp_type = match ctx_variant.to_string().as_str() {
+            "SyscallsEnterOpen" => quote!(tp_type::SyscallsEnterOpen),
             "SyscallsExitOpen" => quote!(tp_type::SyscallsExitOpen),
-            _ => panic!("Please provide valid tp_type"),
+            "SyscallsEnterDup" => quote!(tp_type::SyscallsEnterDup),
+            _ => abort_call_site!("Please provide valid context type"),
         };
+
+        let wrapper_name = format_ident!("{}_wrapper", fn_name);
 
         let function_body_tokens = quote! {
             #[inline(always)]
             #item
 
+            #[inline(always)]
+            fn #wrapper_name(obj: &tracepoint, ctx_wrapper: tp_ctx) -> Result {
+                let tp_ctx::#ctx_variant(ctx) = ctx_wrapper else {
+                    return Err(0);
+                };
+                #fn_name(obj, ctx)
+            }
+
             #[used]
             #[unsafe(link_section = #attached_name)]
             static #prog_ident: tracepoint =
-                tracepoint::new(#fn_name, #function_name, #tp_type);
+                tracepoint::new(#wrapper_name, #function_name, #tp_type);
         };
 
         Ok(function_body_tokens)

--- a/rex/src/tracepoint/binding.rs
+++ b/rex/src/tracepoint/binding.rs
@@ -1,7 +1,7 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SyscallsEnterOpenArgs {
-    pub unused: u64,
+    unused: u64,
     pub syscall_nr: i64,
     pub filename_ptr: i64,
     pub flags: i64,
@@ -11,7 +11,15 @@ pub struct SyscallsEnterOpenArgs {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SyscallsExitOpenArgs {
-    pub unused: u64,
+    unused: u64,
     pub syscall_nr: i64,
     pub ret: i64,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SyscallsEnterDupArgs {
+    unused: u64,
+    pub syscall_nr: i64,
+    pub fildes: u64,
 }

--- a/rex/src/tracepoint/binding.rs
+++ b/rex/src/tracepoint/binding.rs
@@ -1,6 +1,6 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct SyscallsEnterOpenArgs {
+pub struct SyscallsEnterOpenCtx {
     unused: u64,
     pub syscall_nr: i64,
     pub filename_ptr: i64,
@@ -10,7 +10,18 @@ pub struct SyscallsEnterOpenArgs {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct SyscallsExitOpenArgs {
+pub struct SyscallsEnterOpenatCtx {
+    unused: u64,
+    pub syscall_nr: i64,
+    pub dfd: i64,
+    pub filename_ptr: i64,
+    pub flags: i64,
+    pub mode: i64,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SyscallsExitOpenCtx {
     unused: u64,
     pub syscall_nr: i64,
     pub ret: i64,
@@ -18,7 +29,15 @@ pub struct SyscallsExitOpenArgs {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct SyscallsEnterDupArgs {
+pub struct SyscallsExitOpenatCtx {
+    unused: u64,
+    pub syscall_nr: i64,
+    pub ret: i64,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct SyscallsEnterDupCtx {
     unused: u64,
     pub syscall_nr: i64,
     pub fildes: u64,

--- a/rex/src/tracepoint/mod.rs
+++ b/rex/src/tracepoint/mod.rs
@@ -1,4 +1,5 @@
 mod binding;
 mod tp_impl;
 
+pub use binding::*;
 pub use tp_impl::*;

--- a/rex/src/tracepoint/tp_impl.rs
+++ b/rex/src/tracepoint/tp_impl.rs
@@ -7,17 +7,6 @@ use crate::Result;
 
 use super::binding::*;
 
-pub enum tp_type {
-    SyscallsEnterOpen,
-    SyscallsExitOpen,
-    SyscallsEnterDup,
-}
-pub enum tp_ctx {
-    SyscallsEnterOpen(&'static SyscallsEnterOpenArgs),
-    SyscallsExitOpen(&'static SyscallsExitOpenArgs),
-    SyscallsEnterDup(&'static SyscallsEnterDupArgs),
-}
-
 /// First 3 fields should always be rtti, prog_fn, and name
 ///
 /// rtti should be u64, therefore after compiling the
@@ -30,38 +19,23 @@ pub enum tp_ctx {
 #[repr(C)]
 pub struct tracepoint {
     rtti: u64,
-    prog: fn(&Self, tp_ctx) -> Result,
+    prog: fn(&Self, *mut ()) -> Result,
     name: &'static str,
-    tp_type: tp_type,
 }
 
+// unlike other programs, we don't perform context conversion here
+// as it is handled by the [#rex_tracepoint] macro
 impl tracepoint {
     crate::base_helper::base_helper_defs!();
 
     pub const fn new(
-        f: fn(&tracepoint, tp_ctx) -> Result,
+        f: fn(&tracepoint, *mut ()) -> Result,
         nm: &'static str,
-        tp_ty: tp_type,
     ) -> tracepoint {
         Self {
             rtti: BPF_PROG_TYPE_TRACEPOINT as u64,
             prog: f,
             name: nm,
-            tp_type: tp_ty,
-        }
-    }
-
-    fn convert_ctx(&self, ctx: *mut ()) -> tp_ctx {
-        match self.tp_type {
-            tp_type::SyscallsEnterOpen => tp_ctx::SyscallsEnterOpen(unsafe {
-                &*(ctx as *mut SyscallsEnterOpenArgs)
-            }),
-            tp_type::SyscallsExitOpen => tp_ctx::SyscallsExitOpen(unsafe {
-                &*(ctx as *mut SyscallsExitOpenArgs)
-            }),
-            tp_type::SyscallsEnterDup => tp_ctx::SyscallsEnterDup(unsafe {
-                &*(ctx as *mut &SyscallsEnterDupArgs)
-            }),
         }
     }
 
@@ -72,7 +46,6 @@ impl tracepoint {
 
 impl rex_prog for tracepoint {
     fn prog_run(&self, ctx: *mut ()) -> u32 {
-        let newctx = self.convert_ctx(ctx);
-        ((self.prog)(self, newctx)).unwrap_or_else(|e| e) as u32
+        ((self.prog)(self, ctx)).unwrap_or_else(|e| e) as u32
     }
 }

--- a/rex/src/tracepoint/tp_impl.rs
+++ b/rex/src/tracepoint/tp_impl.rs
@@ -8,14 +8,14 @@ use crate::Result;
 use super::binding::*;
 
 pub enum tp_type {
-    Void,
     SyscallsEnterOpen,
     SyscallsExitOpen,
+    SyscallsEnterDup,
 }
 pub enum tp_ctx {
-    Void,
     SyscallsEnterOpen(&'static SyscallsEnterOpenArgs),
     SyscallsExitOpen(&'static SyscallsExitOpenArgs),
+    SyscallsEnterDup(&'static SyscallsEnterDupArgs),
 }
 
 /// First 3 fields should always be rtti, prog_fn, and name
@@ -53,12 +53,14 @@ impl tracepoint {
 
     fn convert_ctx(&self, ctx: *mut ()) -> tp_ctx {
         match self.tp_type {
-            tp_type::Void => tp_ctx::Void,
             tp_type::SyscallsEnterOpen => tp_ctx::SyscallsEnterOpen(unsafe {
                 &*(ctx as *mut SyscallsEnterOpenArgs)
             }),
             tp_type::SyscallsExitOpen => tp_ctx::SyscallsExitOpen(unsafe {
                 &*(ctx as *mut SyscallsExitOpenArgs)
+            }),
+            tp_type::SyscallsEnterDup => tp_ctx::SyscallsEnterDup(unsafe {
+                &*(ctx as *mut &SyscallsEnterDupArgs)
             }),
         }
     }

--- a/samples/hello/src/main.rs
+++ b/samples/hello/src/main.rs
@@ -3,13 +3,13 @@
 
 extern crate rex;
 
-use rex::Result;
 use rex::rex_printk;
 use rex::rex_tracepoint;
 use rex::tracepoint::*;
+use rex::Result;
 
-#[rex_tracepoint(name = "syscalls/sys_enter_dup", tp_type = "Void")]
-fn rex_prog1(obj: &tracepoint, _: tp_ctx) -> Result {
+#[rex_tracepoint(name = "syscalls/sys_enter_dup")]
+fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupArgs) -> Result {
     let option_task = obj.bpf_get_current_task();
     if let Some(task) = option_task {
         let cpu = obj.bpf_get_smp_processor_id();

--- a/samples/hello/src/main.rs
+++ b/samples/hello/src/main.rs
@@ -8,8 +8,8 @@ use rex::rex_tracepoint;
 use rex::tracepoint::*;
 use rex::Result;
 
-#[rex_tracepoint(name = "syscalls/sys_enter_dup")]
-fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupArgs) -> Result {
+#[rex_tracepoint]
+fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupCtx) -> Result {
     let option_task = obj.bpf_get_current_task();
     if let Some(task) = option_task {
         let cpu = obj.bpf_get_smp_processor_id();

--- a/samples/map_test/src/main.rs
+++ b/samples/map_test/src/main.rs
@@ -7,7 +7,7 @@ use rex::linux::bpf::BPF_ANY;
 use rex::map::*;
 use rex::rex_tracepoint;
 use rex::tracepoint::*;
-use rex::{Result, rex_map, rex_printk};
+use rex::{rex_map, rex_printk, Result};
 
 #[rex_map]
 static MAP_HASH: RexHashMap<u32, i64> = RexHashMap::new(1024, 0);
@@ -92,8 +92,8 @@ fn map_test2(obj: &tracepoint) -> Result {
     Ok(0)
 }
 
-#[rex_tracepoint(name = "syscalls/sys_enter_dup", tp_type = "Void")]
-fn rex_prog1(obj: &tracepoint, _: tp_ctx) -> Result {
+#[rex_tracepoint(name = "syscalls/sys_enter_dup")]
+fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupArgs) -> Result {
     map_test1(obj)
         .or_else(|e| rex_printk!("map_test1 failed with {}.\n", e))?;
     map_test2(obj).or_else(|e| rex_printk!("map_test2 failed with {}.\n", e))

--- a/samples/map_test/src/main.rs
+++ b/samples/map_test/src/main.rs
@@ -92,8 +92,8 @@ fn map_test2(obj: &tracepoint) -> Result {
     Ok(0)
 }
 
-#[rex_tracepoint(name = "syscalls/sys_enter_dup")]
-fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupArgs) -> Result {
+#[rex_tracepoint]
+fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupCtx) -> Result {
     map_test1(obj)
         .or_else(|e| rex_printk!("map_test1 failed with {}.\n", e))?;
     map_test2(obj).or_else(|e| rex_printk!("map_test2 failed with {}.\n", e))

--- a/samples/map_test_2/src/main.rs
+++ b/samples/map_test_2/src/main.rs
@@ -6,7 +6,7 @@ extern crate rex;
 use rex::map::*;
 use rex::rex_tracepoint;
 use rex::tracepoint::*;
-use rex::{Result, rex_map, rex_printk};
+use rex::{rex_map, rex_printk, Result};
 
 #[rex_map]
 static MAP_HASH: RexHashMap<u32, i64> = RexHashMap::new(1024, 0);
@@ -191,8 +191,8 @@ fn map_test_ringbuf(obj: &tracepoint) -> Result {
 }
 */
 
-#[rex_tracepoint(name = "syscalls/sys_enter_dup", tp_type = "Void")]
-fn rex_prog1(obj: &tracepoint, _: tp_ctx) -> Result {
+#[rex_tracepoint(name = "syscalls/sys_enter_dup")]
+fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupArgs) -> Result {
     map_test_hash(obj)
         .or_else(|e| rex_printk!("map_test failed with {}.\n", e))?;
     map_test_array(obj)

--- a/samples/map_test_2/src/main.rs
+++ b/samples/map_test_2/src/main.rs
@@ -191,8 +191,8 @@ fn map_test_ringbuf(obj: &tracepoint) -> Result {
 }
 */
 
-#[rex_tracepoint(name = "syscalls/sys_enter_dup")]
-fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupArgs) -> Result {
+#[rex_tracepoint]
+fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupCtx) -> Result {
     map_test_hash(obj)
         .or_else(|e| rex_printk!("map_test failed with {}.\n", e))?;
     map_test_array(obj)

--- a/samples/spinlock_test/src/main.rs
+++ b/samples/spinlock_test/src/main.rs
@@ -6,7 +6,7 @@ extern crate rex;
 use rex::linux::bpf::bpf_spin_lock;
 use rex::map::RexArrayMap;
 use rex::spinlock::rex_spinlock_guard;
-use rex::{Result, rex_map};
+use rex::{rex_map, Result};
 use rex::{rex_tracepoint, tracepoint::*};
 
 #[repr(C)]
@@ -38,8 +38,8 @@ fn test2(obj: &tracepoint) {
     }
 }
 
-#[rex_tracepoint(name = "syscalls/sys_enter_dup", tp_type = "Void")]
-fn rex_prog1(obj: &tracepoint, _: tp_ctx) -> Result {
+#[rex_tracepoint(name = "syscalls/sys_enter_dup")]
+fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupArgs) -> Result {
     test1(obj);
     test2(obj);
     Ok(0)

--- a/samples/spinlock_test/src/main.rs
+++ b/samples/spinlock_test/src/main.rs
@@ -38,8 +38,8 @@ fn test2(obj: &tracepoint) {
     }
 }
 
-#[rex_tracepoint(name = "syscalls/sys_enter_dup")]
-fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupArgs) -> Result {
+#[rex_tracepoint]
+fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupCtx) -> Result {
     test1(obj);
     test2(obj);
     Ok(0)

--- a/samples/syscall_tp/src/main.rs
+++ b/samples/syscall_tp/src/main.rs
@@ -29,34 +29,34 @@ fn count(obj: &tracepoint, map: &'static SyscallTpMap) -> Result {
     Ok(0)
 }
 
-#[rex_tracepoint(name = "syscalls/sys_enter_open")]
+#[rex_tracepoint]
 fn trace_enter_open(
     obj: &tracepoint,
-    _: &'static SyscallsEnterOpenArgs,
+    _: &'static SyscallsEnterOpenCtx,
 ) -> Result {
     count(obj, &enter_open_map)
 }
 
-#[rex_tracepoint(name = "syscalls/sys_enter_openat")]
+#[rex_tracepoint]
 fn trace_enter_open_at(
     obj: &tracepoint,
-    _: &'static SyscallsEnterOpenArgs,
+    _: &'static SyscallsEnterOpenatCtx,
 ) -> Result {
     count(obj, &enter_open_map)
 }
 
-#[rex_tracepoint(name = "syscalls/sys_exit_open")]
+#[rex_tracepoint]
 fn trace_enter_exit(
     obj: &tracepoint,
-    _: &'static SyscallsExitOpenArgs,
+    _: &'static SyscallsExitOpenCtx,
 ) -> Result {
     count(obj, &exit_open_map)
 }
 
-#[rex_tracepoint(name = "syscalls/sys_exit_openat")]
+#[rex_tracepoint]
 fn trace_enter_exit_at(
     obj: &tracepoint,
-    _: &'static SyscallsExitOpenArgs,
+    _: &'static SyscallsExitOpenatCtx,
 ) -> Result {
     count(obj, &exit_open_map)
 }

--- a/samples/syscall_tp/src/main.rs
+++ b/samples/syscall_tp/src/main.rs
@@ -5,8 +5,8 @@ extern crate rex;
 
 use rex::linux::bpf::BPF_NOEXIST;
 use rex::map::RexArrayMap;
-use rex::tracepoint::{tp_ctx, tp_type, tracepoint};
-use rex::{Result, rex_map, rex_tracepoint};
+use rex::tracepoint::*;
+use rex::{rex_map, rex_tracepoint, Result};
 
 #[rex_map]
 static enter_open_map: RexArrayMap<u32> = RexArrayMap::new(1, 0);
@@ -29,31 +29,34 @@ fn count(obj: &tracepoint, map: &'static SyscallTpMap) -> Result {
     Ok(0)
 }
 
-#[rex_tracepoint(
-    name = "syscalls/sys_enter_open",
-    tp_type = "SyscallsEnterOpen"
-)]
-fn trace_enter_open(obj: &tracepoint, _: tp_ctx) -> Result {
+#[rex_tracepoint(name = "syscalls/sys_enter_open")]
+fn trace_enter_open(
+    obj: &tracepoint,
+    _: &'static SyscallsEnterOpenArgs,
+) -> Result {
     count(obj, &enter_open_map)
 }
 
-#[rex_tracepoint(
-    name = "syscalls/sys_enter_openat",
-    tp_type = "SyscallsEnterOpen"
-)]
-fn trace_enter_open_at(obj: &tracepoint, _: tp_ctx) -> Result {
+#[rex_tracepoint(name = "syscalls/sys_enter_openat")]
+fn trace_enter_open_at(
+    obj: &tracepoint,
+    _: &'static SyscallsEnterOpenArgs,
+) -> Result {
     count(obj, &enter_open_map)
 }
 
-#[rex_tracepoint(name = "syscalls/sys_exit_open", tp_type = "SyscallsExitOpen")]
-fn trace_enter_exit(obj: &tracepoint, _: tp_ctx) -> Result {
+#[rex_tracepoint(name = "syscalls/sys_exit_open")]
+fn trace_enter_exit(
+    obj: &tracepoint,
+    _: &'static SyscallsExitOpenArgs,
+) -> Result {
     count(obj, &exit_open_map)
 }
 
-#[rex_tracepoint(
-    name = "syscalls/sys_exit_openat",
-    tp_type = "SyscallsExitOpen"
-)]
-fn trace_enter_exit_at(obj: &tracepoint, _: tp_ctx) -> Result {
+#[rex_tracepoint(name = "syscalls/sys_exit_openat")]
+fn trace_enter_exit_at(
+    obj: &tracepoint,
+    _: &'static SyscallsExitOpenArgs,
+) -> Result {
     count(obj, &exit_open_map)
 }


### PR DESCRIPTION
Attempt to fix #21 by changing the `rex_tracepoint` macro so that the function it takes in can directly name the tracepoint context type.

Also as a side effect, we can remove specifying `tp_type` in the macro, along with automatically inferring the hook point from context type.