### PR TITLE
CI Refactor

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -1,4 +1,9 @@
 name: Meson Build and Test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main, ci]

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,4 +1,9 @@
 name: Meson Build and Test via nix
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main, ci]

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,35 @@
+name: Formatting check
+
+on:
+  push:
+    branches: [main, ci]
+    paths-ignore:
+      - docs/**
+      - tools/**
+      - README.md
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - docs/**
+      - tools/**
+      - README.md
+
+jobs:
+  formatting:
+    if: github.repository == 'rex-rs/rex'
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: switch rust nightly
+        run: |
+          rustup default nightly
+          rustup component add rustfmt
+      - name: formatting rex code
+        run: cargo fmt
+      - name: formatting samples code
+        run: |
+          for d in $(find ./samples -name Cargo.toml); do
+            echo "→ Processing $d"
+            cargo fmt --manifest-path $d --verbose --check
+          done

--- a/rex-macros/src/args.rs
+++ b/rex-macros/src/args.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
-use syn::{parse_str, spanned::Spanned, Expr, ExprAssign, Lit, LitStr, Result};
+use syn::spanned::Spanned;
+use syn::{parse_str, Expr, ExprAssign, Lit, LitStr, Result};
 
 macro_rules! pop_string_args {
     ($self:expr, $key:expr) => {

--- a/rex-macros/src/lib.rs
+++ b/rex-macros/src/lib.rs
@@ -6,14 +6,14 @@ mod tc;
 mod tracepoint;
 mod xdp;
 
-use proc_macro::TokenStream;
-use proc_macro_error::{abort, proc_macro_error};
-use quote::quote;
 use std::borrow::Cow;
-use syn::ItemStatic;
 
 use kprobe::KProbe;
 use perf_event::PerfEvent;
+use proc_macro::TokenStream;
+use proc_macro_error::{abort, proc_macro_error};
+use quote::quote;
+use syn::ItemStatic;
 use tc::SchedCls;
 use tracepoint::TracePoint;
 use xdp::Xdp;

--- a/rex/build.rs
+++ b/rex/build.rs
@@ -1,11 +1,10 @@
 #![feature(exit_status_error)]
 
-use std::env;
-use std::fs;
 use std::io::Result;
 use std::path::Path;
 use std::process::Command;
 use std::string::String;
+use std::{env, fs};
 
 fn main() -> Result<()> {
     let out_dir = env::var("OUT_DIR").unwrap();

--- a/rex/rustfmt.toml
+++ b/rex/rustfmt.toml
@@ -1,4 +1,0 @@
-max_width = 80
-binop_separator = "Back"
-reorder_impl_items = true
-wrap_comments = true

--- a/rex/src/base_helper.rs
+++ b/rex/src/base_helper.rs
@@ -1,3 +1,7 @@
+// use crate::timekeeping::*;
+use core::intrinsics::unlikely;
+use core::mem::MaybeUninit;
+
 use crate::ffi;
 use crate::linux::bpf::bpf_map_type;
 use crate::linux::errno::EINVAL;
@@ -5,10 +9,6 @@ use crate::map::*;
 use crate::per_cpu::{cpu_number, this_cpu_read};
 use crate::random32::bpf_user_rnd_u32;
 use crate::utils::{to_result, NoRef, Result};
-use core::mem::MaybeUninit;
-// use crate::timekeeping::*;
-
-use core::intrinsics::unlikely;
 
 macro_rules! termination_check {
     ($func:expr) => {{
@@ -445,5 +445,4 @@ macro_rules! base_helper_defs {
     };
 }
 
-pub(crate) use base_helper_defs;
-pub(crate) use termination_check;
+pub(crate) use {base_helper_defs, termination_check};

--- a/rex/src/debug.rs
+++ b/rex/src/debug.rs
@@ -1,6 +1,4 @@
-use core::ffi::c_uchar;
-
-use core::ffi::c_int;
+use core::ffi::{c_int, c_uchar};
 
 use crate::ffi;
 

--- a/rex/src/kprobe/kprobe_impl.rs
+++ b/rex/src/kprobe/kprobe_impl.rs
@@ -1,9 +1,8 @@
 use crate::bindings::uapi::linux::bpf::{bpf_map_type, BPF_PROG_TYPE_KPROBE};
-use crate::ffi;
 use crate::prog_type::rex_prog;
 use crate::pt_regs::PtRegs;
 use crate::task_struct::TaskStruct;
-use crate::Result;
+use crate::{ffi, Result};
 
 /// First 3 fields should always be rtti, prog_fn, and name
 ///

--- a/rex/src/lib.rs
+++ b/rex/src/lib.rs
@@ -31,10 +31,10 @@ mod random32;
 
 extern crate paste;
 
-use crate::prog_type::rex_prog;
+use paste::paste;
 pub use rex_macros::*;
 
-use paste::paste;
+use crate::prog_type::rex_prog;
 
 #[cfg(not(CONFIG_KALLSYMS_ALL = "y"))]
 compile_error!("CONFIG_KALLSYMS_ALL is required for rex");

--- a/rex/src/perf_event/perf_event_impl.rs
+++ b/rex/src/perf_event/perf_event_impl.rs
@@ -1,10 +1,10 @@
-use crate::bindings::linux::kernel::bpf_perf_event_data_kern;
+use core::intrinsics::unlikely;
 
+use crate::base_helper::termination_check;
+use crate::bindings::linux::kernel::bpf_perf_event_data_kern;
 use crate::bindings::uapi::linux::bpf::{
     bpf_map_type, bpf_perf_event_value, BPF_PROG_TYPE_PERF_EVENT,
 };
-
-use crate::base_helper::termination_check;
 use crate::ffi;
 use crate::linux::errno::EINVAL;
 use crate::map::*;
@@ -12,8 +12,6 @@ use crate::prog_type::rex_prog;
 use crate::pt_regs::PtRegs;
 use crate::task_struct::TaskStruct;
 use crate::utils::{to_result, NoRef, Result};
-
-use core::intrinsics::unlikely;
 
 #[repr(transparent)]
 pub struct bpf_perf_event_data {

--- a/rex/src/pt_regs.rs
+++ b/rex/src/pt_regs.rs
@@ -1,5 +1,6 @@
-use crate::bindings::linux::kernel::pt_regs;
 use paste::paste;
+
+use crate::bindings::linux::kernel::pt_regs;
 
 /// Transparently wraps around the kernel-internal `struct pt_regs` and make the
 /// fields read-only to prevent user-defined code from modifying the registers

--- a/rex/src/sched_cls/sched_cls_impl.rs
+++ b/rex/src/sched_cls/sched_cls_impl.rs
@@ -1,5 +1,7 @@
-use crate::ffi;
+use core::ffi::{c_char, c_uchar};
+use core::{mem, slice};
 
+use crate::base_helper::termination_check;
 use crate::bindings::linux::kernel::{
     ethhdr, iphdr, sk_buff, sock, tcphdr, udphdr,
 };
@@ -8,12 +10,9 @@ pub use crate::bindings::uapi::linux::bpf::BPF_PROG_TYPE_SCHED_CLS;
 pub use crate::bindings::uapi::linux::pkt_cls::{
     TC_ACT_OK, TC_ACT_REDIRECT, TC_ACT_SHOT,
 };
+use crate::ffi;
 use crate::prog_type::rex_prog;
 use crate::utils::*;
-
-use crate::base_helper::termination_check;
-use core::ffi::{c_char, c_uchar};
-use core::{mem, slice};
 
 pub struct __sk_buff<'a> {
     pub data_slice: &'a mut [c_uchar],

--- a/rex/src/xdp/xdp_impl.rs
+++ b/rex/src/xdp/xdp_impl.rs
@@ -1,20 +1,20 @@
-use crate::ffi;
+use core::ffi::c_uchar;
+use core::mem::size_of;
+use core::{mem, slice};
 
 use crate::base_helper::termination_check;
 pub use crate::bindings::linux::kernel::{
     ethhdr, iphdr, tcphdr, udphdr, xdp_buff,
 };
 use crate::bindings::uapi::linux::bpf::bpf_map_type;
-use crate::prog_type::rex_prog;
-use crate::utils::*;
-use core::ffi::c_uchar;
-use core::{mem, mem::size_of, slice};
-
 // expose the following constants to the user
 pub use crate::bindings::uapi::linux::bpf::{
     BPF_PROG_TYPE_XDP, XDP_ABORTED, XDP_DROP, XDP_PASS, XDP_REDIRECT, XDP_TX,
 };
 pub use crate::bindings::uapi::linux::r#in::{IPPROTO_TCP, IPPROTO_UDP};
+use crate::ffi;
+use crate::prog_type::rex_prog;
+use crate::utils::*;
 
 impl iphdr {
     #[inline(always)]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/atomic/rustfmt.toml
+++ b/samples/atomic/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/atomic/src/main.rs
+++ b/samples/atomic/src/main.rs
@@ -3,9 +3,10 @@
 extern crate rex;
 
 use core::sync::atomic::{AtomicU64, Ordering};
+
+use rex::kprobe::*;
 use rex::pt_regs::PtRegs;
-use rex::{Result, rex_printk};
-use rex::{kprobe::*, rex_kprobe};
+use rex::{Result, rex_kprobe, rex_printk};
 
 static ATOM: AtomicU64 = AtomicU64::new(42);
 

--- a/samples/bmc/rustfmt.toml
+++ b/samples/bmc/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/error_injector/src/main.rs
+++ b/samples/error_injector/src/main.rs
@@ -1,12 +1,10 @@
 #![no_std]
 #![no_main]
 
-use rex::Result;
 use rex::kprobe::kprobe;
 use rex::map::RexHashMap;
 use rex::pt_regs::PtRegs;
-use rex::rex_kprobe;
-use rex::rex_map;
+use rex::{Result, rex_kprobe, rex_map};
 
 #[allow(non_upper_case_globals)]
 #[rex_map]

--- a/samples/hello/rustfmt.toml
+++ b/samples/hello/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/hello/src/main.rs
+++ b/samples/hello/src/main.rs
@@ -3,10 +3,8 @@
 
 extern crate rex;
 
-use rex::Result;
-use rex::rex_printk;
-use rex::rex_tracepoint;
 use rex::tracepoint::*;
+use rex::{Result, rex_printk, rex_tracepoint};
 
 #[rex_tracepoint]
 fn rex_prog1(obj: &tracepoint, _: &'static SyscallsEnterDupCtx) -> Result {

--- a/samples/map_bench/rustfmt.toml
+++ b/samples/map_bench/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/map_test/rustfmt.toml
+++ b/samples/map_test/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/map_test/src/main.rs
+++ b/samples/map_test/src/main.rs
@@ -5,9 +5,8 @@ extern crate rex;
 
 use rex::linux::bpf::BPF_ANY;
 use rex::map::*;
-use rex::rex_tracepoint;
 use rex::tracepoint::*;
-use rex::{Result, rex_map, rex_printk};
+use rex::{Result, rex_map, rex_printk, rex_tracepoint};
 
 #[rex_map]
 static MAP_HASH: RexHashMap<u32, i64> = RexHashMap::new(1024, 0);

--- a/samples/map_test_2/rustfmt.toml
+++ b/samples/map_test_2/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/map_test_2/src/main.rs
+++ b/samples/map_test_2/src/main.rs
@@ -3,13 +3,12 @@
 
 extern crate rex;
 
+use core::mem;
+
 use rex::map::*;
-use rex::rex_tracepoint;
 use rex::tracepoint::*;
 use rex::utils::convert_slice_to_struct_mut;
-use rex::{Result, rex_map, rex_printk};
-
-use core::mem;
+use rex::{Result, rex_map, rex_printk, rex_tracepoint};
 
 #[rex_map]
 static MAP_HASH: RexHashMap<u32, i64> = RexHashMap::new(1024, 0);

--- a/samples/recursive/rustfmt.toml
+++ b/samples/recursive/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/recursive/src/main.rs
+++ b/samples/recursive/src/main.rs
@@ -2,15 +2,13 @@
 #![no_main]
 extern crate rex;
 
-use rex::rex_kprobe;
-use rex::rex_printk;
 // use rex::tracepoint::*;
 use core::hint::black_box;
-use rex::Result;
+
 use rex::kprobe::*;
 use rex::map::RexArrayMap;
 use rex::pt_regs::PtRegs;
-use rex::rex_map;
+use rex::{Result, rex_kprobe, rex_map, rex_printk};
 
 #[rex_map]
 static data_map: RexArrayMap<u32> = RexArrayMap::new(2, 0);

--- a/samples/spinlock_cleanup_benchmark/rustfmt.toml
+++ b/samples/spinlock_cleanup_benchmark/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/spinlock_cleanup_benchmark/src/main.rs
+++ b/samples/spinlock_cleanup_benchmark/src/main.rs
@@ -7,8 +7,7 @@ use rex::linux::bpf::bpf_spin_lock;
 use rex::map::RexArrayMap;
 use rex::spinlock::rex_spinlock_guard;
 use rex::xdp::*;
-use rex::{Result, rex_map};
-use rex::{rex_printk, rex_xdp};
+use rex::{Result, rex_map, rex_printk, rex_xdp};
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/samples/spinlock_test/rustfmt.toml
+++ b/samples/spinlock_test/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/spinlock_test/src/main.rs
+++ b/samples/spinlock_test/src/main.rs
@@ -6,8 +6,8 @@ extern crate rex;
 use rex::linux::bpf::bpf_spin_lock;
 use rex::map::RexArrayMap;
 use rex::spinlock::rex_spinlock_guard;
-use rex::{Result, rex_map};
-use rex::{rex_tracepoint, tracepoint::*};
+use rex::tracepoint::*;
+use rex::{Result, rex_map, rex_tracepoint};
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/samples/startup_overhead_benchmark/rustfmt.toml
+++ b/samples/startup_overhead_benchmark/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/startup_overhead_benchmark/src/main.rs
+++ b/samples/startup_overhead_benchmark/src/main.rs
@@ -3,10 +3,9 @@
 
 extern crate rex;
 
-use rex::Result;
 use rex::kprobe::*;
 use rex::pt_regs::PtRegs;
-use rex::rex_kprobe;
+use rex::{Result, rex_kprobe};
 
 #[rex_kprobe(function = "kprobe_target_func")]
 fn rex_prog1(_obj: &kprobe, _ctx: &mut PtRegs) -> Result {

--- a/samples/syscall_tp/rustfmt.toml
+++ b/samples/syscall_tp/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/trace_event/rustfmt.toml
+++ b/samples/trace_event/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/trace_event/src/main.rs
+++ b/samples/trace_event/src/main.rs
@@ -7,8 +7,7 @@ use rex::linux::bpf::*;
 use rex::linux::perf_event::PERF_MAX_STACK_DEPTH;
 use rex::map::*;
 use rex::perf_event::*;
-use rex::rex_printk;
-use rex::{Result, rex_map, rex_perf_event};
+use rex::{Result, rex_map, rex_perf_event, rex_printk};
 
 pub const TASK_COMM_LEN: usize = 16;
 

--- a/samples/tracex5/rustfmt.toml
+++ b/samples/tracex5/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/tracex5/src/main.rs
+++ b/samples/tracex5/src/main.rs
@@ -4,13 +4,11 @@
 
 extern crate rex;
 
-use rex::Result;
 use rex::kprobe::*;
 use rex::linux::seccomp::seccomp_data;
 use rex::linux::unistd::*;
 use rex::pt_regs::PtRegs;
-use rex::rex_kprobe;
-use rex::rex_printk;
+use rex::{Result, rex_kprobe, rex_printk};
 
 pub fn func_sys_write(obj: &kprobe, ctx: &PtRegs) -> Result {
     let mut sd: seccomp_data = seccomp_data {

--- a/samples/xdp_test/rustfmt.toml
+++ b/samples/xdp_test/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/samples/xdp_test/src/main.rs
+++ b/samples/xdp_test/src/main.rs
@@ -6,11 +6,10 @@ extern crate rex;
 
 use core::net::Ipv4Addr;
 
-use rex::rex_printk;
 use rex::sched_cls::*;
 use rex::utils::*;
 use rex::xdp::*;
-use rex::{rex_tc, rex_xdp};
+use rex::{rex_printk, rex_tc, rex_xdp};
 
 #[rex_xdp]
 fn xdp_rx_filter(obj: &xdp, ctx: &mut xdp_md) -> Result {

--- a/tools/memcached_benchmark/rustfmt.toml
+++ b/tools/memcached_benchmark/rustfmt.toml
@@ -2,3 +2,5 @@ max_width = 80
 binop_separator = "Back"
 reorder_impl_items = true
 wrap_comments = true
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"

--- a/tools/memcached_benchmark/src/dict.rs
+++ b/tools/memcached_benchmark/src/dict.rs
@@ -1,15 +1,17 @@
-use std::{collections::HashMap, mem::size_of_val, sync::Arc};
+use std::collections::HashMap;
+use std::mem::size_of_val;
+use std::sync::Arc;
 
 use log::{debug, info};
-use rand::{
-    Rng,
-    distr::{Alphanumeric, SampleString},
-};
-use rand_chacha::{ChaCha8Rng, rand_core::SeedableRng};
+use rand::Rng;
+use rand::distr::{Alphanumeric, SampleString};
+use rand_chacha::ChaCha8Rng;
+use rand_chacha::rand_core::SeedableRng;
 use rand_distr::Zipf;
 use rayon::prelude::*;
 
-use crate::{Protocol, fs::write_hashmap_to_file};
+use crate::Protocol;
+use crate::fs::write_hashmap_to_file;
 
 const SEED: u64 = 12312;
 

--- a/tools/memcached_benchmark/src/fs.rs
+++ b/tools/memcached_benchmark/src/fs.rs
@@ -1,9 +1,7 @@
-use std::{
-    collections::HashMap,
-    fs::File,
-    io::{BufRead, BufReader, Write},
-    path::Path,
-};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
 
 use anyhow::Result;
 use log::{debug, info};

--- a/tools/memcached_benchmark/src/get_values.rs
+++ b/tools/memcached_benchmark/src/get_values.rs
@@ -1,14 +1,15 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, atomic::*},
-};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::*;
 
 use anyhow::Result;
 use async_memcached::AsciiProtocol;
 use clap::ValueEnum;
 use log::{info, trace};
 use serde::{Deserialize, Serialize};
-use tokio::{net::UdpSocket, sync::mpsc, time::timeout};
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio::time::timeout;
 use tokio_util::task::TaskTracker;
 
 use crate::{BUFFER_SIZE, TIMEOUT_COUNTER};

--- a/tools/memcached_benchmark/src/main.rs
+++ b/tools/memcached_benchmark/src/main.rs
@@ -6,11 +6,10 @@ mod fs;
 mod get_values;
 mod set_values;
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, atomic::*},
-    vec,
-};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::*;
+use std::vec;
 
 use anyhow::{Result, anyhow};
 use clap::Parser;

--- a/tools/memcached_benchmark/src/set_values.rs
+++ b/tools/memcached_benchmark/src/set_values.rs
@@ -1,9 +1,11 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_memcached::AsciiProtocol;
 use log::info;
-use tokio::{sync::Semaphore, task::JoinSet};
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
 
 pub(super) async fn set_memcached_value(
     test_dict: Arc<HashMap<Arc<String>, Arc<String>>>,

--- a/tools/memcached_benchmark/tests/benchmark_test.rs
+++ b/tools/memcached_benchmark/tests/benchmark_test.rs
@@ -1,7 +1,9 @@
-use std::{thread, time::Duration};
+use std::thread;
+use std::time::Duration;
 
 use anyhow::{Ok, Result};
-use assert_cmd::{Command, assert::OutputAssertExt};
+use assert_cmd::Command;
+use assert_cmd::assert::OutputAssertExt;
 use duct::{Handle, cmd};
 use log::{debug, info};
 use tempfile::TempDir;


### PR DESCRIPTION
- rustfmt: set imports_granularity to Module and group_imports to StdExternalCrate
- ci: use concurrency to cancel redundant in‑flight runs
    Use the concurrency feature to cancel any in‑progress run before
    starting the next one, so only the latest CI run executes; all earlier
    ones get canceled, this is applied per branch and PR.
- ci: add check rust formating github workflow
