### PR TITLE
Electrode refactor and fix

### DIFF
--- a/samples/electrode/src/common.rs
+++ b/samples/electrode/src/common.rs
@@ -31,6 +31,9 @@ pub(crate) const BROADCAST_SIGN_BIT: u32 = 1 << 31;
 pub(crate) const QUORUM_SIZE: u32 = (CLUSTER_SIZE as u32 + 1) >> 1;
 pub(crate) const QUORUM_BITSET_ENTRY: u32 = 1024; // must be 2^t
 
+pub(crate) const PAXOS_PORT: u16 = 12345;
+pub(crate) const MAGIC_BITS: [u8; MAGIC_LEN] = [0x18, 0x03, 0x05, 0x20];
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(C)]
 pub(crate) enum ReplicaStatus {

--- a/samples/electrode/src/main.rs
+++ b/samples/electrode/src/main.rs
@@ -106,7 +106,7 @@ fn fast_broad_cast_main(obj: &sched_cls, skb: &mut __sk_buff) -> Result {
                 rex_printk!("data_slice.len() < header_len\n").ok();
                 return Ok(TC_ACT_OK as i32);
             }
-            let payload = &skb.data_slice;
+            let payload = &skb.data_slice[header_len..];
 
             // check for the magic bits and Paxos port
             // only port 12345 is allowed


### PR DESCRIPTION
- Replace the hard-coded Paxos port number and magic-flag bit mask with
named `const` values, which simplify the code structure
- Introduce a reusable `read_field_be!` macro in `rex::utils` that extracts
big-endian numeric fields from packet headers using `offset_of!` +
`convert_slice_to_struct`
- Fix the access of wrong index of magic bits in skb payload.