### PR TITLE
Bump Rust to 1.88.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -146,6 +146,7 @@
         zoxide # in case host is using zoxide
         openssh # q-script ssh support
         zsh
+        xz
       ];
 
       llvmBuildFHSEnv = pkgs.buildFHSEnv.override { stdenv = pkgs.llvmPackages.stdenv; };

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,8 @@ rust_bootstrap = custom_target(
     '--set', 'install.prefix=@OUTDIR@/rust-dist'
   ],
   console: true,
-  build_by_default: false
+  build_by_default: false,
+  env: ['RUSTFLAGS=-Z threads=8 -C link-arg=-fuse-ld=mold']
 )
 
 all_programs = custom_target('build_deps',


### PR DESCRIPTION
Also enabled parallel frontend (`-Z threads=8`) and `mold` (`-C link-arg=-fuse-ld=mold`) to speed up the bootstrap process.