### PR TITLE
Remove all entry generation code from LLVM

### DIFF
--- a/rex-macros/src/args.rs
+++ b/rex-macros/src/args.rs
@@ -14,7 +14,7 @@ macro_rules! pop_string_args {
 pub(crate) fn parse_string_args(
     input: TokenStream,
 ) -> Result<HashMap<String, LitStr>> {
-    let parsed: syn::ExprArray = parse_str(&format!("[{}]", input))?;
+    let parsed: syn::ExprArray = parse_str(&format!("[{input}]"))?;
     let mut map = HashMap::new();
 
     // Iterate over the expressions and extract key-value pairs

--- a/rex-macros/src/kprobe.rs
+++ b/rex-macros/src/kprobe.rs
@@ -65,7 +65,7 @@ impl KProbe {
 
             #[used]
             static #prog_ident: kprobe =
-                kprobe::new(#fn_name, #function_name);
+                kprobe::new(#fn_name);
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = #attached_function)]

--- a/rex-macros/src/kprobe.rs
+++ b/rex-macros/src/kprobe.rs
@@ -47,14 +47,14 @@ impl KProbe {
     pub(crate) fn expand(&self, flavor: KprobeFlavor) -> Result<TokenStream> {
         let fn_name = self.item.sig.ident.clone();
         let item = &self.item;
-        let function_name = format!("{}", fn_name);
+        let function_name = format!("{fn_name}");
         let prog_ident =
             format_ident!("PROG_{}", fn_name.to_string().to_uppercase());
 
         let attached_function = if self.function.is_some() {
             format!("rex/{}/{}", flavor, self.function.as_ref().unwrap())
         } else {
-            format!("rex/{}", flavor)
+            format!("rex/{flavor}")
         };
 
         let entry_name = format_ident!("__rex_entry_{}", fn_name);

--- a/rex-macros/src/kprobe.rs
+++ b/rex-macros/src/kprobe.rs
@@ -65,7 +65,7 @@ impl KProbe {
 
             #[used]
             static #prog_ident: kprobe =
-                kprobe::new(#fn_name);
+                unsafe { kprobe::new(#fn_name) };
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = #attached_function)]

--- a/rex-macros/src/perf_event.rs
+++ b/rex-macros/src/perf_event.rs
@@ -20,7 +20,7 @@ impl PerfEvent {
         // TODO: section may update in the future
         let fn_name = self.item.sig.ident.clone();
         let item = &self.item;
-        let function_name = format!("{}", fn_name);
+        let function_name = format!("{fn_name}");
         let prog_ident =
             format_ident!("PROG_{}", fn_name.to_string().to_uppercase());
 

--- a/rex-macros/src/perf_event.rs
+++ b/rex-macros/src/perf_event.rs
@@ -32,7 +32,7 @@ impl PerfEvent {
 
             #[used]
             static #prog_ident: perf_event =
-                perf_event::new(#fn_name, #function_name);
+                perf_event::new(#fn_name);
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = "rex/perf_event")]

--- a/rex-macros/src/perf_event.rs
+++ b/rex-macros/src/perf_event.rs
@@ -24,14 +24,22 @@ impl PerfEvent {
         let prog_ident =
             format_ident!("PROG_{}", fn_name.to_string().to_uppercase());
 
+        let entry_name = format_ident!("__rex_entry_{}", fn_name);
+
         let function_body_tokens = quote! {
             #[inline(always)]
             #item
 
             #[used]
-            #[unsafe(link_section = "rex/perf_event")]
             static #prog_ident: perf_event =
                 perf_event::new(#fn_name, #function_name);
+
+            #[unsafe(export_name = #function_name)]
+            #[unsafe(link_section = "rex/perf_event")]
+            extern "C" fn #entry_name(ctx: *mut ()) -> u32 {
+                use rex::prog_type::rex_prog;
+                #prog_ident.prog_run(ctx)
+            }
         };
         Ok(function_body_tokens)
     }

--- a/rex-macros/src/perf_event.rs
+++ b/rex-macros/src/perf_event.rs
@@ -32,7 +32,7 @@ impl PerfEvent {
 
             #[used]
             static #prog_ident: perf_event =
-                perf_event::new(#fn_name);
+                unsafe { perf_event::new(#fn_name) };
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = "rex/perf_event")]

--- a/rex-macros/src/tc.rs
+++ b/rex-macros/src/tc.rs
@@ -28,14 +28,22 @@ impl SchedCls {
         let prog_ident =
             format_ident!("PROG_{}", fn_name.to_string().to_uppercase());
 
+        let entry_name = format_ident!("__rex_entry_{}", fn_name);
+
         let function_body_tokens = quote! {
             #[inline(always)]
             #item
 
             #[used]
-            #[unsafe(link_section = "rex/tc")]
             static #prog_ident: sched_cls =
                 sched_cls::new(#fn_name, #function_name);
+
+            #[unsafe(export_name = #function_name)]
+            #[unsafe(link_section = "rex/tc")]
+            extern "C" fn #entry_name(ctx: *mut ()) -> u32 {
+                use rex::prog_type::rex_prog;
+                #prog_ident.prog_run(ctx)
+            }
         };
         Ok(function_body_tokens)
     }

--- a/rex-macros/src/tc.rs
+++ b/rex-macros/src/tc.rs
@@ -24,7 +24,7 @@ impl SchedCls {
         // TODO: section may update in the future
         let fn_name = self.item.sig.ident.clone();
         let item = &self.item;
-        let function_name = format!("{}", fn_name);
+        let function_name = format!("{fn_name}");
         let prog_ident =
             format_ident!("PROG_{}", fn_name.to_string().to_uppercase());
 

--- a/rex-macros/src/tc.rs
+++ b/rex-macros/src/tc.rs
@@ -36,7 +36,7 @@ impl SchedCls {
 
             #[used]
             static #prog_ident: sched_cls =
-                sched_cls::new(#fn_name);
+                unsafe { sched_cls::new(#fn_name) };
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = "rex/tc")]

--- a/rex-macros/src/tc.rs
+++ b/rex-macros/src/tc.rs
@@ -36,7 +36,7 @@ impl SchedCls {
 
             #[used]
             static #prog_ident: sched_cls =
-                sched_cls::new(#fn_name, #function_name);
+                sched_cls::new(#fn_name);
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = "rex/tc")]

--- a/rex-macros/src/tracepoint.rs
+++ b/rex-macros/src/tracepoint.rs
@@ -68,7 +68,7 @@ impl TracePoint {
 
             #[used]
             static #prog_ident: tracepoint<#full_context_type> =
-                tracepoint::new(#fn_name, #function_name);
+                tracepoint::new(#fn_name);
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = #attached_name)]

--- a/rex-macros/src/tracepoint.rs
+++ b/rex-macros/src/tracepoint.rs
@@ -68,7 +68,7 @@ impl TracePoint {
 
             #[used]
             static #prog_ident: tracepoint<#full_context_type> =
-                tracepoint::new(#fn_name);
+               unsafe { tracepoint::new(#fn_name) };
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = #attached_name)]

--- a/rex-macros/src/tracepoint.rs
+++ b/rex-macros/src/tracepoint.rs
@@ -44,7 +44,7 @@ impl TracePoint {
 
         // other tracepoint pieces
         let item = &self.item;
-        let function_name = format!("{}", fn_name);
+        let function_name = format!("{fn_name}");
         let prog_ident =
             format_ident!("PROG_{}", fn_name.to_string().to_uppercase());
 
@@ -58,7 +58,7 @@ impl TracePoint {
             "RawSyscallsExitCtx" => "raw_syscalls/sys_exit",
             _ => abort_call_site!("Please provide a valid context type. If your needed context isn't supported consider opening a PR!"),
         };
-        let attached_name = format!("rex/tracepoint/{}", hook_point_name);
+        let attached_name = format!("rex/tracepoint/{hook_point_name}");
 
         let entry_name = format_ident!("__rex_entry_{}", fn_name);
 

--- a/rex-macros/src/xdp.rs
+++ b/rex-macros/src/xdp.rs
@@ -25,14 +25,22 @@ impl Xdp {
         let prog_ident =
             format_ident!("PROG_{}", fn_name.to_string().to_uppercase());
 
+        let entry_name = format_ident!("__rex_entry_{}", fn_name);
+
         let function_body_tokens = quote! {
             #[inline(always)]
             #item
 
             #[used]
-            #[unsafe(link_section = "rex/xdp")]
             static #prog_ident: xdp =
                 xdp::new(#fn_name, #function_name);
+
+            #[unsafe(export_name = #function_name)]
+            #[unsafe(link_section = "rex/xdp")]
+            extern "C" fn #entry_name(ctx: *mut ()) -> u32 {
+                use rex::prog_type::rex_prog;
+                #prog_ident.prog_run(ctx)
+            }
         };
         Ok(function_body_tokens)
     }

--- a/rex-macros/src/xdp.rs
+++ b/rex-macros/src/xdp.rs
@@ -33,7 +33,7 @@ impl Xdp {
 
             #[used]
             static #prog_ident: xdp =
-                xdp::new(#fn_name, #function_name);
+                xdp::new(#fn_name);
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = "rex/xdp")]

--- a/rex-macros/src/xdp.rs
+++ b/rex-macros/src/xdp.rs
@@ -21,7 +21,7 @@ impl Xdp {
         // TODO: section may update in the future
         let fn_name = self.item.sig.ident.clone();
         let item = &self.item;
-        let function_name = format!("{}", fn_name);
+        let function_name = format!("{fn_name}");
         let prog_ident =
             format_ident!("PROG_{}", fn_name.to_string().to_uppercase());
 

--- a/rex-macros/src/xdp.rs
+++ b/rex-macros/src/xdp.rs
@@ -33,7 +33,7 @@ impl Xdp {
 
             #[used]
             static #prog_ident: xdp =
-                xdp::new(#fn_name);
+                unsafe { xdp::new(#fn_name) };
 
             #[unsafe(export_name = #function_name)]
             #[unsafe(link_section = "rex/xdp")]

--- a/rex/src/kprobe/kprobe_impl.rs
+++ b/rex/src/kprobe/kprobe_impl.rs
@@ -1,37 +1,20 @@
-use crate::bindings::uapi::linux::bpf::{bpf_map_type, BPF_PROG_TYPE_KPROBE};
+use crate::bindings::uapi::linux::bpf::bpf_map_type;
 use crate::prog_type::rex_prog;
 use crate::pt_regs::PtRegs;
 use crate::task_struct::TaskStruct;
 use crate::{ffi, Result};
 
-/// First 3 fields should always be rtti, prog_fn, and name
-///
-/// rtti should be u64, therefore after compiling the
-/// packed struct type rustc generates for LLVM does
-/// not additional padding after rtti
-///
 /// prog_fn should have &Self as its first argument
-///
-/// name is a &'static str
 #[repr(C)]
 pub struct kprobe {
-    rtti: u64,
     prog: fn(&Self, &mut PtRegs) -> Result,
-    name: &'static str,
 }
 
 impl kprobe {
     crate::base_helper::base_helper_defs!();
 
-    pub const fn new(
-        f: fn(&kprobe, &mut PtRegs) -> Result,
-        nm: &'static str,
-    ) -> kprobe {
-        Self {
-            rtti: BPF_PROG_TYPE_KPROBE as u64,
-            prog: f,
-            name: nm,
-        }
+    pub const fn new(f: fn(&kprobe, &mut PtRegs) -> Result) -> kprobe {
+        Self { prog: f }
     }
 
     // Now returns a mutable ref, but since every reg is private the user prog

--- a/rex/src/kprobe/kprobe_impl.rs
+++ b/rex/src/kprobe/kprobe_impl.rs
@@ -13,7 +13,7 @@ pub struct kprobe {
 impl kprobe {
     crate::base_helper::base_helper_defs!();
 
-    pub const fn new(f: fn(&kprobe, &mut PtRegs) -> Result) -> kprobe {
+    pub const unsafe fn new(f: fn(&kprobe, &mut PtRegs) -> Result) -> kprobe {
         Self { prog: f }
     }
 

--- a/rex/src/perf_event/perf_event_impl.rs
+++ b/rex/src/perf_event/perf_event_impl.rs
@@ -42,7 +42,7 @@ pub struct perf_event {
 impl perf_event {
     crate::base_helper::base_helper_defs!();
 
-    pub const fn new(
+    pub const unsafe fn new(
         f: fn(&perf_event, &bpf_perf_event_data) -> Result,
     ) -> perf_event {
         Self { prog: f }

--- a/rex/src/sched_cls/sched_cls_impl.rs
+++ b/rex/src/sched_cls/sched_cls_impl.rs
@@ -173,7 +173,9 @@ pub struct sched_cls {
 impl sched_cls {
     crate::base_helper::base_helper_defs!();
 
-    pub const fn new(f: fn(&sched_cls, &mut __sk_buff) -> Result) -> sched_cls {
+    pub const unsafe fn new(
+        f: fn(&sched_cls, &mut __sk_buff) -> Result,
+    ) -> sched_cls {
         Self { prog: f }
     }
 

--- a/rex/src/sched_cls/sched_cls_impl.rs
+++ b/rex/src/sched_cls/sched_cls_impl.rs
@@ -6,7 +6,6 @@ use crate::bindings::linux::kernel::{
     ethhdr, iphdr, sk_buff, sock, tcphdr, udphdr,
 };
 use crate::bindings::uapi::linux::bpf::bpf_map_type;
-pub use crate::bindings::uapi::linux::bpf::BPF_PROG_TYPE_SCHED_CLS;
 pub use crate::bindings::uapi::linux::pkt_cls::{
     TC_ACT_OK, TC_ACT_REDIRECT, TC_ACT_SHOT,
 };
@@ -165,35 +164,17 @@ impl<'a> __sk_buff<'a> {
     }
 }
 
-/// First 3 fields should always be rtti, prog_fn, and name
-///
-/// rtti should be u64, therefore after compiling the
-/// packed struct type rustc generates for LLVM does
-/// not additional padding after rtti
-///
 /// prog_fn should have &Self as its first argument
-///
-/// name is a &'static str
 #[repr(C)]
 pub struct sched_cls {
-    rtti: u64,
     prog: fn(&Self, &mut __sk_buff) -> Result,
-    name: &'static str,
 }
 
 impl sched_cls {
     crate::base_helper::base_helper_defs!();
 
-    pub const fn new(
-        // TODO update based on signature
-        f: fn(&sched_cls, &mut __sk_buff) -> Result,
-        nm: &'static str,
-    ) -> sched_cls {
-        Self {
-            rtti: BPF_PROG_TYPE_SCHED_CLS as u64,
-            prog: f,
-            name: nm,
-        }
+    pub const fn new(f: fn(&sched_cls, &mut __sk_buff) -> Result) -> sched_cls {
+        Self { prog: f }
     }
 
     // NOTE: copied from xdp impl, may change in the future

--- a/rex/src/tracepoint/tp_impl.rs
+++ b/rex/src/tracepoint/tp_impl.rs
@@ -4,9 +4,7 @@ use super::{
     SyscallsExitOpenatCtx,
 };
 use crate::base_helper::termination_check;
-use crate::bindings::uapi::linux::bpf::{
-    bpf_map_type, BPF_PROG_TYPE_TRACEPOINT,
-};
+use crate::bindings::uapi::linux::bpf::bpf_map_type;
 use crate::map::RexPerfEventArray;
 use crate::prog_type::rex_prog;
 use crate::task_struct::TaskStruct;
@@ -22,20 +20,10 @@ impl TracepointContext for SyscallsEnterDupCtx {}
 impl TracepointContext for RawSyscallsEnterCtx {}
 impl TracepointContext for RawSyscallsExitCtx {}
 
-/// First 3 fields should always be rtti, prog_fn, and name
-///
-/// rtti should be u64, therefore after compiling the
-/// packed struct type rustc generates for LLVM does
-/// not additional padding after rtti
-///
 /// prog_fn should have &Self as its first argument
-///
-/// name is a &'static str
 #[repr(C)]
 pub struct tracepoint<C: TracepointContext + 'static> {
-    rtti: u64,
     prog: fn(&Self, &'static C) -> Result,
-    name: &'static str,
 }
 
 impl<C: TracepointContext + 'static> tracepoint<C> {
@@ -43,13 +31,8 @@ impl<C: TracepointContext + 'static> tracepoint<C> {
 
     pub const fn new(
         f: fn(&tracepoint<C>, &'static C) -> Result,
-        nm: &'static str,
     ) -> tracepoint<C> {
-        Self {
-            rtti: BPF_PROG_TYPE_TRACEPOINT as u64,
-            prog: f,
-            name: nm,
-        }
+        Self { prog: f }
     }
 
     fn convert_ctx(&self, ctx: *mut ()) -> &'static C {

--- a/rex/src/tracepoint/tp_impl.rs
+++ b/rex/src/tracepoint/tp_impl.rs
@@ -29,7 +29,7 @@ pub struct tracepoint<C: TracepointContext + 'static> {
 impl<C: TracepointContext + 'static> tracepoint<C> {
     crate::base_helper::base_helper_defs!();
 
-    pub const fn new(
+    pub const unsafe fn new(
         f: fn(&tracepoint<C>, &'static C) -> Result,
     ) -> tracepoint<C> {
         Self { prog: f }

--- a/rex/src/xdp/xdp_impl.rs
+++ b/rex/src/xdp/xdp_impl.rs
@@ -9,7 +9,7 @@ pub use crate::bindings::linux::kernel::{
 use crate::bindings::uapi::linux::bpf::bpf_map_type;
 // expose the following constants to the user
 pub use crate::bindings::uapi::linux::bpf::{
-    BPF_PROG_TYPE_XDP, XDP_ABORTED, XDP_DROP, XDP_PASS, XDP_REDIRECT, XDP_TX,
+    XDP_ABORTED, XDP_DROP, XDP_PASS, XDP_REDIRECT, XDP_TX,
 };
 pub use crate::bindings::uapi::linux::r#in::{IPPROTO_TCP, IPPROTO_UDP};
 use crate::ffi;
@@ -81,34 +81,17 @@ impl xdp_md<'_> {
     }
 }
 
-/// First 3 fields should always be rtti, prog_fn, and name
-///
-/// rtti should be u64, therefore after compiling the
-/// packed struct type rustc generates for LLVM does
-/// not additional padding after rtti
-///
 /// prog_fn should have &Self as its first argument
-///
-/// name is a &'static str
 #[repr(C)]
 pub struct xdp {
-    rtti: u64,
     prog: fn(&Self, &mut xdp_md) -> Result,
-    name: &'static str,
 }
 
 impl xdp {
     crate::base_helper::base_helper_defs!();
 
-    pub const fn new(
-        f: fn(&xdp, &mut xdp_md) -> Result,
-        nm: &'static str,
-    ) -> xdp {
-        Self {
-            rtti: BPF_PROG_TYPE_XDP as u64,
-            prog: f,
-            name: nm,
-        }
+    pub const fn new(f: fn(&xdp, &mut xdp_md) -> Result) -> xdp {
+        Self { prog: f }
     }
 
     // Now returns a mutable ref, but since every reg is private the user prog

--- a/rex/src/xdp/xdp_impl.rs
+++ b/rex/src/xdp/xdp_impl.rs
@@ -90,7 +90,7 @@ pub struct xdp {
 impl xdp {
     crate::base_helper::base_helper_defs!();
 
-    pub const fn new(f: fn(&xdp, &mut xdp_md) -> Result) -> xdp {
+    pub const unsafe fn new(f: fn(&xdp, &mut xdp_md) -> Result) -> xdp {
         Self { prog: f }
     }
 


### PR DESCRIPTION
A long time overdue, we will use this PR to group the lastover changes needed to move from LLVM backend code generation to proc-macros.