### PR TITLE
Rust version bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1758427187,
+        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
There have been changes to x.py since you last updated:
  [WARNING] It is no longer possible to `x build` with stage 0. All build commands have to be on stage 1+.
    - PR Link https://github.com/rust-lang/rust/pull/142581
  [INFO] It is no longer possible to combine `rust.lld = true` with configuring external LLVM using `llvm.llvm-config`.
    - PR Link https://github.com/rust-lang/rust/pull/143175
  [WARNING] `rust.lld` is no longer enabled by default for the dist profile.
    - PR Link https://github.com/rust-lang/rust/pull/143255
  [INFO] Added new option `build.tidy-extra-checks` to specify a default value for the --extra-checks cli flag.
    - PR Link https://github.com/rust-lang/rust/pull/143251
  [WARNING] The `spellcheck:fix` tidy extra check argument has been removed, use `--bless` instead
    - PR Link https://github.com/rust-lang/rust/pull/143493
  [WARNING] The default check stage has been changed to 1. It is no longer possible to `x check` with stage 0. All check commands have to be on stage 1+. Bootstrap tools can now also only be checked for the host target.
    - PR Link https://github.com/rust-lang/rust/pull/143048
  [WARNING] `download-rustc` has been temporarily disabled for the library profile due to implementation bugs (see #142505).
    - PR Link https://github.com/rust-lang/rust/pull/143577
  [INFO] The --extra-checks flag now supports prefixing any check with `auto:` to only run it if relevant files are modified
    - PR Link https://github.com/rust-lang/rust/pull/143398
  [INFO] A --compile-time-deps flag has been added to reduce the time it takes rust-analyzer to start
    - PR Link https://github.com/rust-lang/rust/pull/143785
  [INFO] Option `tool.TOOL_NAME.features` now works on any subcommand, not just `build`.
    - PR Link https://github.com/rust-lang/rust/pull/143733
  [WARNING] The current `./x suggest` implementation has been removed due to it being quite broken and a lack of maintenance bandwidth, with no prejudice against re-implementing it in a more maintainable form.
    - PR Link https://github.com/rust-lang/rust/pull/143630
  [WARNING] Removed `rust.description` and `llvm.ccache` as it was deprecated in #137723 and #136941 long time ago.
    - PR Link https://github.com/rust-lang/rust/pull/143926
  [WARNING] Added `build.compiletest-allow-stage0` flag instead of `COMPILETEST_FORCE_STAGE0` env var, and reject running `compiletest` self tests against stage 0 rustc unless explicitly allowed.
    - PR Link https://github.com/rust-lang/rust/pull/144675
NOTE: to silence this warning, update `bootstrap.toml` to use `change-id = 144675` or `change-id = "ignore"` instead
```

@jinghao-jia  Can you confirm if I missed any configuration updates, thanks~