### PR TITLE
Fix `addtionally` -> `additionally` typo

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ kernel.  The steps below describe how to set up both the toolchain and
 kernel for running Rex extensions in a VM.
 
 Rex currently only supports the `x86-64` (`amd64`) architecture. Running
-Rex in VMs addtionally requires
+Rex in VMs additionally requires
 [`KVM`](https://linux-kvm.org/page/Main_Page) to be available on the host
 machine.
 


### PR DESCRIPTION
Line 9 of `docs/getting-started.md` has `addtionally`.