### PR TITLE
meson: remove libclang C library check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,8 +48,6 @@ assert(
   python3_bin.language_version().version_compare('>=3.11'),
   'python3 >= 3.11 is required'
 )
-cc = meson.get_compiler('c')
-cc.find_library('clang', required: true)
 realpath = find_program('realpath')
 lld = find_program('ld.lld')
 bc = find_program('bc')


### PR DESCRIPTION
The check for python libclang binding should already be enough as it is backed by libclang C library.